### PR TITLE
chore(plugin): update minimum requirements & WooCommerce compatibility

### DIFF
--- a/fast-woo-order-lookup.php
+++ b/fast-woo-order-lookup.php
@@ -12,6 +12,11 @@
  * Plugin URI:    https://plumislandmedia.net/wordpress-plugins/fast-woo-order-lookup/
  * Description:   Look up orders faster in large WooCommerce stores with many orders.
  * Version:       1.1.1
+ * Requires at least: 5.8
+ * Requires PHP: 5.6
+ * WC requires at least: 4.0
+ * WC tested up to: 9.1.4
+ * Requires Plugins: woocommerce
  * Author:        Ollie Jones
  * Author URI:    https://github.com/OllieJones
  * Text Domain:   fast-woo-order-lookup


### PR DESCRIPTION
Hello, 
I've updated the plugin header to include minimum requirements and testing information:

Requires at least: 5.8 for WordPress, as this version has been available since July 20, 2021 ([WordPress 5.8 Release Notes](https://wordpress.org/documentation/wordpress-version/version-5-8/)). Many major plugins also require this version.

Requires PHP: 5.6 as specified on the plugin's page on WordPress.org. However, since PHP 5.6 is end-of-life ([PHP End of Life](https://endoflife.date/php)) and unsupported, it might be prudent to increase the minimum PHP version. PHP 7.4 is a reasonable choice, offering extended support through repositories like Debian's Sury ([Freexian's PHP LTS](https://www.freexian.com/lts/php/)).

The new plugin dependency feature, introduced in WordPress 6.5 (2024), simplifies managing plugin requirements, making installation and activation smoother. More info: [Introducing Plugin Dependencies in WordPress 6.5](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/).

WC requires at least: 4.0, which dates back to pre-COVID times. Feel free to adjust if necessary.

WC tested up to: 9.1.4, aligning with the latest WooCommerce release close to the plugin's last update ([WooCommerce 9.1.3 Release Notes](https://developer.woocommerce.com/2024/07/26/woocommerce-9-1-3-dot-release/) dated July 26).

Added Requires Plugins: woocommerce to specify the dependency.

Links are included where relevant for easy reference.