### PR TITLE
feat(ci): add dependabot config for GitHub Actions daily updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR introduces Dependabot configuration for daily updates to GitHub Actions. 
For more information, check the official [documentation](https://docs.github.com/github/managing-security-vulnerabilities/configuring-dependabot-security-updates).
