### PR TITLE
Integration of Composer and PHP CodeSniffer for Improved Standards Compliance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/lint_phpcs.yml
+++ b/.github/workflows/lint_phpcs.yml
@@ -1,0 +1,34 @@
+name: WPCS check
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+
+    name: Fast Woo Order Lookup lint with PHPCS. PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        coverage: none  # XDebug can be enabled here 'coverage: xdebug'
+        tools: composer:v2
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-interaction --no-scripts
+
+    - name: Lint with phpcs
+      run: composer phpcs

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *~
 **/hidden-test-treeshake/
 
-/vendor/
+/vendor/*
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,70 @@
+{
+    "name": "olliejones/fast-woo-order-lookup",
+    "description": "WooCommerce / WordPress plugin to speed up searches for orders",
+    "keywords": [
+        "wordpress",
+        "performance",
+        "search",
+        "database"
+    ],
+    "homepage": "https://wordpress.org/plugins/fast-woo-order-lookup/",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Oliver Jones",
+            "email": "olliejones@gmail.com",
+            "homepage": "https://www.plumislandmedia.net"
+        }
+    ],
+    "type": "wordpress-plugin",
+    "config": {
+        "sort-packages": true,
+        "process-timeout": 0,
+        "allow-plugins": {
+            "composer/installers": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
+        }
+    },
+    "support": {
+        "issues": "https://github.com/OllieJones/fast-woo-order-lookup/issues",
+        "source": "https://github.com/OllieJones/fast-woo-order-lookup"
+    },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://wpackagist.org"
+        }
+    ],
+    "require": {
+        "php": ">=5.6"
+    },
+    "require-dev": {
+        "php": "^7 || ^8",
+        "phpcompatibility/phpcompatibility-wp": "*",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+        "phpunit/phpunit": "^7.5 || ^8 || ^9",
+        "wp-coding-standards/wpcs": "^3",
+        "phpstan/phpstan": "^1.12",
+        "squizlabs/php_codesniffer": "^3.10",
+        "php-stubs/wordpress-tests-stubs": "^6.6",
+        "phpstan/phpstan-phpunit": "^1.4",
+        "szepeviktor/phpstan-wordpress": "^1.3",
+        "phpstan/extension-installer": "^1.4",
+        "roave/security-advisories": "dev-master",
+        "woocommerce/action-scheduler": "^3.8",
+        "wpackagist-plugin/woocommerce": "^8"
+    },
+    "scripts": {
+        "run-stan": "vendor/bin/phpstan analyze --memory-limit=2G --no-progress",
+        "install-codestandards": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
+        "phpcs": "phpcs --basepath=.",
+        "phpcs:fix": "phpcbf",
+        "post-install-cmd": [
+            "composer dump-autoload"
+        ],
+        "post-update-cmd": [
+            "composer dump-autoload"
+        ]
+    }
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<ruleset name="Custom WordPress Standard">
+    <description>Custom WordPress coding standards configuration to exclude non-critical phpcs notices.</description>
+	
+    <arg name="parallel" value="50"/><!-- Enables parallel processing when available for faster results. -->
+	<arg name="extensions" value="php"/><!-- Limit to PHP files -->
+	<arg value="sp"/><!-- Show sniff and progress -->
+	<arg name="colors"/><!-- Show results with colors -->
+	
+	<file>code</file>
+	<file>fast-woo-order-lookup.php</file>
+	<!-- Add more specific exclusions here as needed -->
+    <exclude-pattern>/vendor/*</exclude-pattern>
+	
+	<!-- Rules: Check PHP version compatibility - see https://github.com/PHPCompatibility/PHPCompatibilityWP -->
+	<rule ref="PHPCompatibility"/>
+	<config name="testVersion" value="5.6-"/>
+	<config name="minimum_supported_wp_version" value="5.8"/>
+	
+    <!-- Path to the WordPress Coding Standards -->
+    <rule ref="WordPress">
+	<!-- NEW -->
+	<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
+	<exclude name="Universal.Operators.DisallowShortTernary.Found"/>
+	<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound"/>
+	<exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>
+	<exclude name="Generic.PHP.NoSilencedErrors.Discouraged"/>
+	<exclude name="PEAR.Functions.FunctionCallSignature.Indent"/>
+	<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
+	<exclude name="Squiz.Commenting.FileComment.Missing"/>
+	<exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
+	<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
+	<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+	<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+	
+    <!-- Exclude rules for inline comment formatting -->
+    <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
+    <!-- Exclude rules for missing comments for classes, functions, parameters -->
+    <exclude name="Squiz.Commenting.ClassComment.Missing"/>
+    <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+    <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
+    <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
+    <exclude name="Generic.Commenting.DocComment.MissingShort"/>
+    <exclude name="Squiz.Commenting.VariableComment.Missing"/>
+    <exclude name="Squiz.Commenting.FileComment.Missing"/>
+    <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
+    <!-- Ignore the 'Yoda Conditions' notices -->
+    <exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+    </rule>
+	<rule ref="WordPress.Files.FileName">
+        <properties>
+            <property name="strict_class_file_names" value="false" />
+        </properties>
+    </rule>
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+    
+    <!-- You can specify more rules or modify existing ones to fit your project's needs -->
+</ruleset>


### PR DESCRIPTION
Hello,

This pull request represents a more substantial update compared to my last submission. I have integrated Composer, which I had only used sparingly before, but I have learned a lot about it in the past few hours. After reviewing several popular plugins, I decided to implement Composer for this plugin as well.

In this pull request, not everything is perfect, and there may be adjustments needed in the long term, but for now, it seems adequate.

**Key Changes:**

1. **PHP CodeSniffer Integration:**
   - I have included a custom `phpcs.xml` file. This configuration is not overly strict and is aligned with WordPress coding standards. Please review it to determine if you'd like to adjust the strictness.

2. **Composer Configuration:**
   - The `composer.json` file has been expanded to include more than what is currently necessary, foreseeing future needs. This should not cause any issues at present.
   - I have updated the `.gitignore` to properly exclude the `vendor` directory and included the `composer.lock` file to ensure consistent dependency versions across all setups.

3. **Dependency Management:**
   - Added a `dependabot.yml` configuration for Composer to regularly check and update dependencies, ensuring optimal and secure operation.

4. **Linting Workflow:**
   - Introduced `lint_phpcs.yml`, utilizing a matrix strategy to check PHP versions from 7.3 to 8.3. It's worth noting that versions below PHP 7.3 do not support the dependencies, and PHP 7.3 has been nearing its end-of-life for three years now ([PHP End of Life Dates](https://endoflife.date/php)). It may be beneficial to increase the minimum PHP version supported by the plugin, but it currently functions well across all specified versions.
   - A rule is in place to check compatibility: `<rule ref="PHPCompatibility"/><config name="testVersion" value="5.6-"/>`

This setup has taken several hours to implement and refine. Feel free to make any adjustments to the `composer.json` if you have specific preferences or requirements.

Should you accept this pull request, further code modifications may be necessary, or you might opt to tweak the `phpcs.xml`, though that could be considered a workaround depending on the context :)

I look forward to your feedback and am happy to make any further adjustments as needed.